### PR TITLE
security: restrict workflow token permissions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,6 +7,9 @@ on:
     - cron: "37 14 * * *" # Run at 7:37 AM Pacific Time (14:37 UTC) every day
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another scheduled run starts while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 concurrency:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 concurrency:


### PR DESCRIPTION
## Summary
- add explicit read-only `GITHUB_TOKEN` permissions to unit tests
- add explicit read-only `GITHUB_TOKEN` permissions to integration tests
- resolves CodeQL alerts #3 and #4

## Validation
- [x] `git diff --check`
- [x] parsed both workflow files as YAML